### PR TITLE
Chrome固有のバグ修正（イベントリスナーの削除）

### DIFF
--- a/scratch-vm/src/extensions/scratch3_facemesh2scratch/index.js
+++ b/scratch-vm/src/extensions/scratch3_facemesh2scratch/index.js
@@ -318,6 +318,7 @@ class Scratch3Facemesh2ScratchBlocks {
         this.runtime.ioDevices.video.disableVideo();
         this.facemesh.video = null; // Stop the model prediction if video is off
       } else {
+        this.facemesh.removeAllListeners('predict');
         this.runtime.ioDevices.video.enableVideo().then(this.detectFace);
         this.runtime.ioDevices.video.mirror = state === "on";
       }


### PR DESCRIPTION
Google Chromeのみで発生する以下の問題について解決しました。

1. 拡張機能を読み込み、認識を開始する
2. カメラをOFF（切）にする
3. その後カメラをON（入）にすると認識結果が不安定（数秒に1回しか認識されない）

現状の再現手順としては、

1. Google Chromeを使って [facemesh.sb3](https://github.com/champierre/facemesh2scratch/raw/master/sample_projects/facemesh.sb3) を読み込む（ここで初期化が行われ、顔の認識が開始する）
2. 緑旗を押してサンプルプロジェクトを開始すると、顔の認識結果のメッシュが表示される（ここまでは問題なし）
3. 「カメラを切にする」ブロックをパレットからクリックしてカメラを停止する
4. その後、緑旗を押してサンプルプロジェクトを再度最初から開始するか（サンプルプロジェクトでカメラを入にするのブロックが入っているので、カメラはONになる）、ブロックパレットから「カメラを入にする」のブロックをクリックする
5. 認識が不安定になり、数秒間に1回だけしか顔が認識されない

この問題はposenet2scratchやhandpose2scratchでは発生していません。
posenet2scratchについてはカメラのOFFの方式が違うことが影響しています。
handpose2scratchはほぼfacemeshと同じ形式ですが、同じ問題は発生していません（ここは原因不明です）。

EventEmitterに登録したイベントがカメラOFF後に状態がおかしくなっていることが原因と考えて、カメラ起動の前に既に登録されているイベントリスナーをいったん削除するコードを追加しています。デバッガーでは追えていないのですが、カメラのON/OFFでthis.fashmeshの再取得が行われているのですが、以前に登録したpredictのイベント発生のプロセスが生きているとしか思えない挙動を示していました。

他のブラウザでは発生していないバグなので、Chromeの仕様によるものなのかもしれないと考えています。

この修正によって他のブラウザでの挙動には影響を与えない（WindowsのEdgeとFirefox、MacのSafariとFirefox）ことを確認していますので、修正の検討をお願いします。

修正適用後のテスト環境は以下になります。

https://manabu-s.github.io/facemesh2scratch-test/